### PR TITLE
merge functions in SmsFetcher

### DIFF
--- a/src/fr/unix_experience/owncloud_sms/engine/SmsFetcher.java
+++ b/src/fr/unix_experience/owncloud_sms/engine/SmsFetcher.java
@@ -12,7 +12,7 @@ package fr.unix_experience.owncloud_sms.engine;
  *  but WITHOUT ANY WARRANTY; without even the implied warranty of
  *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  *  GNU Affero General Public License for more details.
- *  
+ *
  *  You should have received a copy of the GNU Affero General Public License
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -23,6 +23,7 @@ import org.json.JSONObject;
 
 import fr.unix_experience.owncloud_sms.enums.MailboxID;
 import fr.unix_experience.owncloud_sms.providers.SmsDataProvider;
+
 import android.content.Context;
 import android.database.Cursor;
 import android.util.Log;
@@ -31,197 +32,85 @@ public class SmsFetcher {
 	public SmsFetcher(Context ct) {
 		_lastMsgDate = (long) 0;
 		_context = ct;
-		
+
 		_existingInboxMessages = null;
 		_existingSentMessages = null;
 		_existingDraftsMessages = null;
 	}
-	
+
 	public JSONArray fetchAllMessages() {
-		_jsonDataDump = new JSONArray();
-		bufferizeMailboxMessages(MailboxID.INBOX);
-		bufferizeMailboxMessages(MailboxID.SENT);
-		bufferizeMailboxMessages(MailboxID.DRAFTS);
-		return _jsonDataDump;
+		JSONArray jsonDataDump = new JSONArray();
+		addMailboxMessagesToJson(jsonDataDump, MailboxID.INBOX, -1);
+		addMailboxMessagesToJson(jsonDataDump, MailboxID.SENT, -1);
+		addMailboxMessagesToJson(jsonDataDump, MailboxID.DRAFTS, -1);
+		return jsonDataDump;
 	}
-	
-	private void bufferizeMailboxMessages(MailboxID mbID) {
-		String mbURI = mapMailboxIDToURI(mbID);
-		
-		if (_context == null || mbURI == null) {
-			return;
-		}
-		
-		if (mbID != MailboxID.INBOX && mbID != MailboxID.SENT &&
-			mbID != MailboxID.DRAFTS) {
-			Log.e(TAG,"Unhandled MailboxID " + mbID.ordinal());
-			return;
-		}
 
-		// We generate a ID list for this message box
-		String existingIDs = buildExistingMessagesString(mbID);
-		
-		Cursor c = null;
-		if (existingIDs.length() > 0) {
-			c = (new SmsDataProvider(_context)).query(mbURI, "_id NOT IN (" + existingIDs + ")");
-		}
-		else {
-			c = (new SmsDataProvider(_context)).query(mbURI);
-		}
-		
-		// Reading mailbox
-		if (c != null && c.getCount() > 0) {
-			c.moveToFirst();
-			do {
-				JSONObject entry = new JSONObject();
+	private void addMailboxMessagesToJson(JSONArray jsonDataDump, MailboxID mbID, Long sinceDate) {
+		// called by fetchAllMessages()				with sinceDate == -1
+		// called by getLastMessage()				with sinceDate == -2
+		// called by bufferizeMessagesSinceDate()	with sinceDate > 0
+		// calling with mbID == MailboxID.ALL and sinceDate == 0 would load ALL messages in ALL mailboxes
 
-				try {
-					for(int idx=0;idx<c.getColumnCount();idx++) {
-						String colName = c.getColumnName(idx);
-						
-						// Id column is must be an integer
-						if (colName.equals(new String("_id")) ||
-							colName.equals(new String("type"))) {
-							entry.put(colName, c.getInt(idx));
-						}
-						// Seen and read must be pseudo boolean
-						else if (colName.equals(new String("read")) ||
-								colName.equals(new String("seen"))) {
-							entry.put(colName, c.getInt(idx) > 0 ? "true" : "false");
-						}
-						else {
-							// Special case for date, we need to record last without searching
-							if (colName.equals(new String("date"))) {
-								final Long tmpDate = c.getLong(idx);
-								if (tmpDate > _lastMsgDate) {
-									_lastMsgDate = tmpDate;
-								}
-							}
-							entry.put(colName, c.getString(idx));
-						}
-					}
-					
-					// Mailbox ID is required by server
-					entry.put("mbox", mbID.ordinal());
-					
-					_jsonDataDump.put(entry);
-					
-				} catch (JSONException e) {
-					Log.e(TAG, "JSON Exception when reading SMS Mailbox", e);
-					c.close();
-				}
-			}
-			while(c.moveToNext());
-			
-			Log.d(TAG, c.getCount() + " messages read from " + mbURI);
-			
-			c.close();
-		}
-	}
-	
-	// Used by Content Observer
-	public JSONArray getLastMessage(MailboxID mbID) {
-		String mbURI = mapMailboxIDToURI(mbID);
-		
-		if (_context == null || mbURI == null) {
+		if (_context == null) {
 			return null;
 		}
-		
-		// Fetch Sent SMS Message from Built-in Content Provider
-		Cursor c = (new SmsDataProvider(_context)).query(mbURI);
-		
-		c.moveToNext();
-		
-		// We create a list of strings to store results
-		JSONArray results = new JSONArray();
-		
-		JSONObject entry = new JSONObject();
 
-		try {
-			Integer mboxId = -1;
-			for(int idx = 0;idx < c.getColumnCount(); idx++) {
-				String colName = c.getColumnName(idx);
-				
-				// Id column is must be an integer
-				if (colName.equals(new String("_id"))) {
-					entry.put(colName, c.getInt(idx));
-				}
-				// Seen and read must be pseudo boolean
-				else if (colName.equals(new String("read")) ||
-						colName.equals(new String("seen"))) {
-					entry.put(colName, c.getInt(idx) > 0 ? "true" : "false");
-				}
-				else if (colName.equals(new String("type"))) {
-					mboxId = c.getInt(idx);
-					entry.put(colName, c.getInt(idx));
-				}
-				else {
-					entry.put(colName, c.getString(idx));
-				}
-			}
-			
-			/*
-			* Mailbox ID is required by server
-			* mboxId is greater than server mboxId by 1 because types 
-			* aren't indexed in the same mean
-			*/
-			entry.put("mbox", (mboxId - 1));
-			
-			results.put(entry);
-		} catch (JSONException e) {
-			Log.e(TAG, "JSON Exception when reading SMS Mailbox", e);
-			c.close();
-		}
-		
-		c.close();
-		
-		return results;
-	}
-	
-	// Used by ConnectivityChanged Event
-	public JSONArray bufferizeMessagesSinceDate(Long sinceDate) {
-		_jsonDataDump = new JSONArray();
-		bufferizeMessagesSinceDate(MailboxID.INBOX, sinceDate);
-		bufferizeMessagesSinceDate(MailboxID.SENT, sinceDate);
-		bufferizeMessagesSinceDate(MailboxID.DRAFTS, sinceDate);
-		return _jsonDataDump;
-	}
-	
-	// Used by ConnectivityChanged Event
-	public void bufferizeMessagesSinceDate(MailboxID mbID, Long sinceDate) {
 		String mbURI = mapMailboxIDToURI(mbID);
-		
-		if (_context == null || mbURI == null) {
-			return;
+
+		if (mbURI == null) {
+			Log.e(TAG, "Unhandled MailboxID " + mbID.ordinal());
+			return null;
 		}
-		
-		Cursor c = new SmsDataProvider(_context).query(mbURI, "date > ?", new String[] { sinceDate.toString() });
-		
+
+		String existingIDs = null;
+		if (sinceDate == (long) -1) {
+			// We generate a ID list for this message box
+			existingIDs = buildExistingMessagesString(mbID);
+		}
+
+		Cursor c = null;
+
+		if (existingIDs.length() > 0) {
+			c = (new SmsDataProvider(_context)).query(mbURI, "_id NOT IN (" + existingIDs + ")");
+		} else if sinceDate > 0){
+			c = (new SmsDataProvider(_context)).query(mbURI, "date > ?", new String[]{sinceDate.toString()});
+		}
+		else{
+			c = (new SmsDataProvider(_context)).query(mbURI);
+		}
+
 		// Reading mailbox
 		if (c != null && c.getCount() > 0) {
-			c.moveToFirst();
+
+			if (sinceDate == -2) {
+				// When called by getLastMessage() then we move to the next message
+				c.moveToNext();
+			} else {
+				c.moveToFirst();
+			}
+
+			Integer mboxId = -1;
+
 			do {
 				JSONObject entry = new JSONObject();
 
 				try {
-					for(int idx=0;idx<c.getColumnCount();idx++) {
+					for (int idx = 0; idx < c.getColumnCount(); idx++) {
 						String colName = c.getColumnName(idx);
-						
+
 						// Id column is must be an integer
-						if (colName.equals(new String("_id")) ||
-							colName.equals(new String("type"))) {
+						if (colName.equals(new String("_id"))) {
 							entry.put(colName, c.getInt(idx));
-							
-							// bufferize Id for future use
-							if (colName.equals(new String("_id"))) {
-							}
 						}
 						// Seen and read must be pseudo boolean
 						else if (colName.equals(new String("read")) ||
 								colName.equals(new String("seen"))) {
 							entry.put(colName, c.getInt(idx) > 0 ? "true" : "false");
-						}
-						else {
+						} else if (colName.equals(new String("type"))) {
+							mboxId = c.getInt(idx);
+							entry.put(colName, c.getInt(idx));
+						} else {
 							// Special case for date, we need to record last without searching
 							if (colName.equals(new String("date"))) {
 								final Long tmpDate = c.getLong(idx);
@@ -232,71 +121,97 @@ public class SmsFetcher {
 							entry.put(colName, c.getString(idx));
 						}
 					}
-					
-					// Mailbox ID is required by server
-					entry.put("mbox", mbID.ordinal());
-					
-					_jsonDataDump.put(entry);
-					
+
+					/*
+					* Mailbox ID is required by server
+					* mboxId is greater than server mboxId by 1 because types
+					* aren't indexed in the same mean
+					*/
+					entry.put("mbox", (mboxId - 1));
+
+					jsonDataDump.put(entry);
+
 				} catch (JSONException e) {
 					Log.e(TAG, "JSON Exception when reading SMS Mailbox", e);
 					c.close();
 				}
 			}
-			while(c.moveToNext());
-			
+			while (sinceDate != -2 && c.moveToNext());
+
 			Log.d(TAG, c.getCount() + " messages read from " + mbURI);
-			
+
 			c.close();
 		}
 	}
-	
+
+	// Used by Content Observer
+	public JSONArray getLastMessage(MailboxID mbID) {
+		JSONArray jsonDataDump = new JSONArray();
+
+		if (addMailboxMessagesToJson(jsonDataDump, mbID, -2) == null) {
+			return null;
+		}
+
+		return jsonDataDump;
+	}
+
+	// Used by ConnectivityChanged Event
+	public JSONArray bufferizeMessagesSinceDate(Long sinceDate) {
+		JSONArray jsonDataDump = new JSONArray();
+		addMailboxMessagesToJson(jsonDataDump, MailboxID.INBOX, sinceDate);
+		addMailboxMessagesToJson(jsonDataDump, MailboxID.SENT, sinceDate);
+		addMailboxMessagesToJson(jsonDataDump, MailboxID.DRAFTS, sinceDate);
+		return jsonDataDump;
+	}
+
 	private String mapMailboxIDToURI(MailboxID mbID) {
 		if (mbID == MailboxID.INBOX) {
 			return "content://sms/inbox";
-		}
-		else if (mbID == MailboxID.DRAFTS) {
+		} else if (mbID == MailboxID.DRAFTS) {
 			return "content://sms/drafts";
-		}
-		else if (mbID == MailboxID.SENT) {
+		} else if (mbID == MailboxID.SENT) {
 			return "content://sms/sent";
-		}
-		else if (mbID == MailboxID.ALL) {
+		} else if (mbID == MailboxID.ALL) {
 			return "content://sms";
 		}
-		
+
 		return null;
 	}
-	
-	private String buildExistingMessagesString(MailboxID _mbID) {
+
+	private String buildExistingMessagesString(MailboxID mbID) {
 		JSONArray existingMessages = null;
-		if (_mbID == MailboxID.INBOX) {
-			existingMessages = _existingInboxMessages;
-		} else if (_mbID == MailboxID.DRAFTS) {
-			existingMessages = _existingDraftsMessages;
-		} else if (_mbID == MailboxID.SENT) {
-			existingMessages = _existingSentMessages;
-		}
-		// Note: The default case isn't possible, we check the mailbox before
-		
+
 		StringBuilder sb = new StringBuilder();
-		if (existingMessages != null) {
-			int len = existingMessages.length(); 
-	        for (int i = 0; i < len; i++) {
-	        	try {
-	        		if (sb.length() > 0) {
-	        			sb.append(",");
-	        		}
-	        		sb.append(existingMessages.getInt(i));
-				} catch (JSONException e) {
-					
+
+		for (MailboxID idx : MailboxID.values()) {
+			if (mbID == idx || mbID == MailboxID.ALL)){
+				existingMessages = _existingInboxMessages;
+			}else if (mbID == idx || mbID == MailboxID.ALL)){
+				existingMessages = _existingDraftsMessages;
+			}else if (mbID == idx || mbID == MailboxID.ALL)){
+				existingMessages = _existingSentMessages;
+			}else{
+				existingMessages = null;
+			}
+
+			if (existingMessages != null) {
+				int len = existingMessages.length();
+				for (int i = 0; i < len; i++) {
+					try {
+						if (sb.length() > 0) {
+							sb.append(",");
+						}
+						sb.append(existingMessages.getInt(i));
+					} catch (JSONException e) {
+
+					}
 				}
-	        }
+			}
 		}
-		
+
 		return sb.toString();
 	}
-	
+
 	public void setExistingInboxMessages(JSONArray inboxMessages) {
 		_existingInboxMessages = inboxMessages;
 	}
@@ -308,18 +223,17 @@ public class SmsFetcher {
 	public void setExistingDraftsMessages(JSONArray draftMessages) {
 		_existingDraftsMessages = draftMessages;
 	}
-	
+
 	public Long getLastMessageDate() {
 		return _lastMsgDate;
 	}
-	
+
 	private Context _context;
-	private JSONArray _jsonDataDump;
 	private JSONArray _existingInboxMessages;
 	private JSONArray _existingSentMessages;
 	private JSONArray _existingDraftsMessages;
-	
+
 	private Long _lastMsgDate;
-	
+
 	private static final String TAG = SmsFetcher.class.getSimpleName();
 }


### PR DESCRIPTION
### reasons for PR
merging the three main functions into one in order to 
* reduce duplicate code,
* enhance maintainability

### changes in details
(`* improvements, + additions, - removals, . enum`):
```
* rename bufferizeMailboxMessages() -> addMailboxMessagesToJson()
  + parameter JSONArray jsonDataDump
  + parameter Long sinceDate
  * generalize handling in order to use the same function from
    . fetchAllMessages()
    . getLastMessage()
    . bufferizeMessagesSinceDate()
* fetchAllMessages()
  * use addMailboxMessagesToJson()
* getLastMessage()
  * use addMailboxMessagesToJson()
* bufferizeMessagesSinceDate()
  * use addMailboxMessagesToJson()
* buildExistingMessagesString()
  * make it compatible to be used with mbID = MailboxID.ALL
```
### references
* https://github.com/nerzhul/ocsms/issues/39#issuecomment-74420974
* https://github.com/nerzhul/ownCloud-SMS-App/commit/48ec96f41bb8862163da8d85c96707febfbb01e0#commitcomment-9763194

### notice
code is untested. not even compiled. as i don't have any running java DE at the moment ...

### questions
in `getLastMessage()` all the messages of all mailboxes get selected. does the curser limit the records due to the `_context` variable? or why did you use `c.moveToNext()`. what would be the current record? what if there where still more?
```
// Fetch Sent SMS Message from Built-in Content Provider
Cursor c = (new SmsDataProvider(_context)).query(mbURI);
c.moveToNext();
```
the implementation of this PR does (should) not change the behaviour of the code in any way. this questions just arose. 