### PR TITLE
Fix classpath dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.2.2'


### PR DESCRIPTION
com.android.tools.build:gradle:2.2.2 is not in mavenCentral, but only in jcenter.